### PR TITLE
upload macho-O

### DIFF
--- a/src/SymbolCollector.Android/Properties/AndroidManifest.xml
+++ b/src/SymbolCollector.Android/Properties/AndroidManifest.xml
@@ -2,6 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="SymbolCollector.Android.SymbolCollector.Android">
 	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="29" />
 	<application android:allowBackup="true" android:label="@string/app_name" android:supportsRtl="true" android:theme="@style/AppTheme">
-        <meta-data android:name="io.sentry.symbol-collector" android:value="https://sentry.garcia.in/image" />
-    </application>
+		<meta-data android:name="io.sentry.symbol-collector" android:value="https://sentry.garcia.in/image" />
+	</application>
 </manifest>

--- a/src/SymbolCollector.Android/Properties/AndroidManifest.xml
+++ b/src/SymbolCollector.Android/Properties/AndroidManifest.xml
@@ -2,6 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="SymbolCollector.Android.SymbolCollector.Android">
 	<uses-sdk android:minSdkVersion="21" android:targetSdkVersion="29" />
 	<application android:allowBackup="true" android:label="@string/app_name" android:supportsRtl="true" android:theme="@style/AppTheme">
-		<meta-data android:name="io.sentry.symbol-collector" android:value="https://sentry.garcia.in/image" />
+		<meta-data android:name="io.sentry.symbol-collector" android:value="https://sentry.garcia.in" />
 	</application>
 </manifest>

--- a/src/SymbolCollector.Console/Program.cs
+++ b/src/SymbolCollector.Console/Program.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Sentry;
@@ -15,7 +17,12 @@ namespace SymbolCollector.Console
         private static async Task UploadSymbols()
         {
             // TODO: Get the paths via parameter or confi file/env var?
-            var paths = new[] {"/lib/", "/usr/lib/", "/usr/local/lib/"};
+            var paths = new List<string> {"/lib/", "/usr/lib/", "/usr/local/lib/"};
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                // TODO: Add per OS paths
+//                paths.Add("");
+            }
 
             var cancellation = new CancellationTokenSource();
             CancelKeyPress += (s, ev) =>
@@ -42,7 +49,11 @@ namespace SymbolCollector.Console
                 o.AttachStacktrace = true;
                 o.Dsn = new Dsn(Dsn);
             });
-            SentrySdk.ConfigureScope(s => s.SetTag("app", typeof(Program).Assembly.GetName().Name));
+            SentrySdk.ConfigureScope(s =>
+            {
+                s.SetTag("app", typeof(Program).Assembly.GetName().Name);
+                s.SetTag("server-endpoint", SymbolCollectorServiceUrl);
+            });
             try
             {
                 await UploadSymbols();

--- a/src/SymbolCollector.Console/Program.cs
+++ b/src/SymbolCollector.Console/Program.cs
@@ -16,6 +16,8 @@ namespace SymbolCollector.Console
 
         private static async Task UploadSymbols()
         {
+            // https://github.com/Tyrrrz/CliFx
+
             // TODO: Get the paths via parameter or confi file/env var?
             var paths = new List<string> {"/lib/", "/usr/lib/", "/usr/local/lib/"};
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))

--- a/src/SymbolCollector.Console/SymbolCollector.Console.csproj
+++ b/src/SymbolCollector.Console/SymbolCollector.Console.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-<!--    <PackageReference Include="Sentry" Version="2.0.0-beta6" />-->
+    <PackageReference Include="Sentry" Version="2.0.0-beta6" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.0.0" />
     <ProjectReference Include="..\..\..\sentry-dotnet\src\Sentry\Sentry.csproj" />
     <ProjectReference Include="..\SymbolCollector.Core\SymbolCollector.Core.csproj" />

--- a/src/SymbolCollector.Core/Client.cs
+++ b/src/SymbolCollector.Core/Client.cs
@@ -27,7 +27,8 @@ namespace SymbolCollector.Core
             HttpMessageHandler? handler = null,
             ILogger<Client>? logger = null)
         {
-            _serviceUri = serviceUri;
+            // We only hit /image here
+            _serviceUri = new Uri(serviceUri, "image");
             _logger = logger ?? NullLogger<Client>.Instance;
             _client = new HttpClient(handler ?? new HttpClientHandler());
         }

--- a/src/SymbolCollector.Server/Properties/launchSettings.json
+++ b/src/SymbolCollector.Server/Properties/launchSettings.json
@@ -2,10 +2,11 @@
   "profiles": {
     "SymbolCollector.Server": {
       "commandName": "Project",
-      "launchBrowser": false,
+      "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+      },
+      "applicationUrl": "http://localhost:5000/"
     }
   }
 }

--- a/test/SymbolCollector.Server.Tests/Properties/launchSettings.json
+++ b/test/SymbolCollector.Server.Tests/Properties/launchSettings.json
@@ -1,0 +1,16 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true
+  },
+  "profiles": {
+    "SymbolCollector.Server.Tests": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:5001;http://localhost:5000"
+    }
+  }
+}


### PR DESCRIPTION
Draft to start discussing this to move on from a PoC into something more production ready:

Right now it goes through some hard-coded paths `"/lib/", "/usr/lib/", "/usr/local/lib/"` and depending whether it's running on macOS or Linux will look for mach-o or elf files.
Suggestions of paths to look for linux and macOS?

~~In case of ELF it only uploads files that contain debug id and also either `.debug_frame` or `.eh_frame` as @jan-auer suggested. Last time I discussed this with @mitsuhiko he suggested we don't do this check and upload any valid ELF. Please advise.~~
- Any valid ELF file gets uploaded now.

The mach-o code only tests if it's a mach-o and hashes the content of the file as uses that as the "debug id".

The server so far uses the debug-id as the file name (so original file name is lost, we need it?), saves all files flat in GCS, right now mixing ELF and Mach-O. 
Since we need to test in the server too for the type, I'd say let's use the same endpoint `/image` and let the server decide where/how to store it. So we can create buckets for ELF and other for Mach-O and split it like that?!