### PR TITLE
fix: Don't cancel batch over disconnect

### DIFF
--- a/send-test-batch.sh
+++ b/send-test-batch.sh
@@ -1,0 +1,18 @@
+export batchId=$(uuidgen)
+export batchFriendlyName="curl-test-batch"
+export batchType="Android"
+export body='{"BatchFriendlyName":"'$batchFriendlyName'","BatchType":"'$batchType'"}'
+export server=http://localhost:5000
+
+curl -sD - --header "Content-Type: application/json" --request POST \
+  --data "$body" \
+  $server/symbol/batch/$batchId/start
+
+curl -i \
+  -F "libxamarin-app-arm64-v8a.so=@test/TestFiles/libxamarin-app-arm64-v8a.so" \
+  -F "libxamarin-app.so=@test/TestFiles/libxamarin-app.so" \
+  $server/symbol/batch/$batchId/upload
+
+curl -sD - --header "Content-Type: application/json" --request POST \
+  --data "{}" \
+  $server/symbol/batch/$batchId/close

--- a/src/SymbolCollector.Server/BatchFinalizer.cs
+++ b/src/SymbolCollector.Server/BatchFinalizer.cs
@@ -96,7 +96,10 @@ namespace SymbolCollector.Server
             {
                 var destinationName = filePath.Replace(trimDown, string.Empty);
                 await using var file = File.OpenRead(filePath);
-                await _gcsWriter.WriteAsync(destinationName, file, token);
+                await _gcsWriter.WriteAsync(destinationName, file,
+                    // The client disconnecting at this point shouldn't affect closing this batch.
+                    // This should anyway be a background job queued by the batch finalizer
+                    CancellationToken.None);
             }
 
             var counter = 0;

--- a/src/SymbolCollector.Server/SymbolService.cs
+++ b/src/SymbolCollector.Server/SymbolService.cs
@@ -271,6 +271,9 @@ namespace SymbolCollector.Server
         {
             var batch = await GetOpenBatch(batchId, token);
 
+            // Client is built with retry and this code isn't idempotent
+            batch.Close();
+
             // TODO: Validate client metrics against data collected (recon)
             batch.ClientMetrics = clientMetrics;
 
@@ -299,8 +302,6 @@ namespace SymbolCollector.Server
                 batchId, destination);
 
             await _batchFinalizer.CloseBatch(destination, batch, token);
-
-            batch.Close();
         }
 
 


### PR DESCRIPTION
Also close the batch at the entrance since it's not idempotent and client retries create confusing errors (can't find the processing folder)