### PR TITLE
sort per file

### DIFF
--- a/send-test-batch.sh
+++ b/send-test-batch.sh
@@ -3,18 +3,28 @@
 export batchId=$(uuidgen)
 export batchFriendlyName="curl-test-batch"
 export batchType="Android"
-export body='{"BatchFriendlyName":"'$batchFriendlyName'","BatchType":"'$batchType'"}'
+export body='{"BatchFriendlyName":"'${batchFriendlyName}'","BatchType":"'${batchType}'"}'
 export server=http://localhost:5000
+
+export startBatchUrl=${server}/symbol/batch/${batchId}/start
+echo -e "\nStarting batch at: $startBatchUrl \n"
 
 curl -sD - --header "Content-Type: application/json" --request POST \
   --data "$body" \
-  $server/symbol/batch/$batchId/start
+  ${startBatchUrl}
+
+
+export uploadFiles=$server/symbol/batch/$batchId/upload
+echo -e "\nUploading files: $uploadFiles \n"
 
 curl -i \
   -F "libxamarin-app-arm64-v8a.so=@test/TestFiles/libxamarin-app-arm64-v8a.so" \
   -F "libxamarin-app.so=@test/TestFiles/libxamarin-app.so" \
-  $server/symbol/batch/$batchId/upload
+  ${uploadFiles}
+
+export closeBatchUrl=${server}/symbol/batch/${batchId}/close
+echo -e "\nClosing batch at: $closeBatchUrl \n"
 
 curl -sD - --header "Content-Type: application/json" --request POST \
   --data "{}" \
-  $server/symbol/batch/$batchId/close
+  ${closeBatchUrl}

--- a/src/SymbolCollector.Console/README.md
+++ b/src/SymbolCollector.Console/README.md
@@ -2,5 +2,10 @@
 
 #### Build the project and upload local symbols and images
 ```sh
-dotnet run -- --upload device
+dotnet run -- --upload device --bundle-id bundle-id-name
+```
+
+#### Build the project and run symsorter on a directory (in dryrun mode)
+```sh
+ddotnet run -- --symsorter ../SymbolCollector.Server/dev-data/done/macos --bundle-id test-symsorter --batch-type macos --path output --dryrun true
 ```

--- a/src/SymbolCollector.Core/BundleIdGenerator.cs
+++ b/src/SymbolCollector.Core/BundleIdGenerator.cs
@@ -1,0 +1,22 @@
+using System;
+using System.IO;
+using System.Linq;
+
+namespace SymbolCollector.Core
+{
+    public class BundleIdGenerator
+    {
+        private readonly SuffixGenerator _suffixGenerator;
+
+        public BundleIdGenerator(SuffixGenerator suffixGenerator) => _suffixGenerator = suffixGenerator;
+
+        public string CreateBundleId(string friendlyName)
+        {
+            var invalids = Path.GetInvalidFileNameChars().Concat(" ").ToArray();
+            return string.Join("_",
+                    friendlyName.Split(invalids, StringSplitOptions.RemoveEmptyEntries)
+                        .Append(_suffixGenerator.Generate()))
+                .TrimEnd('.');
+        }
+    }
+}

--- a/src/SymbolCollector.Core/BundleIdGenerator.cs
+++ b/src/SymbolCollector.Core/BundleIdGenerator.cs
@@ -1,22 +1,26 @@
-using System;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace SymbolCollector.Core
 {
     public class BundleIdGenerator
     {
         private readonly SuffixGenerator _suffixGenerator;
+        private readonly Regex _removeCharsRegex;
 
-        public BundleIdGenerator(SuffixGenerator suffixGenerator) => _suffixGenerator = suffixGenerator;
-
-        public string CreateBundleId(string friendlyName)
+        public BundleIdGenerator(SuffixGenerator suffixGenerator)
         {
-            var invalids = Path.GetInvalidFileNameChars().Concat(" ").ToArray();
-            return string.Join("_",
-                    friendlyName.Split(invalids, StringSplitOptions.RemoveEmptyEntries)
-                        .Append(_suffixGenerator.Generate()))
-                .TrimEnd('.');
+            var invalidChars = Path.GetInvalidFileNameChars()
+                .Concat(new[] {' ', '*', '?', '"', '\n'});
+            var pattern = Regex.Escape(new string(invalidChars.ToArray()));
+            _removeCharsRegex = new Regex($"[{pattern}]", RegexOptions.Compiled);
+            _suffixGenerator = suffixGenerator;
         }
+
+        public string CreateBundleId(string friendlyName) =>
+            _removeCharsRegex
+                .Replace(friendlyName, "_")
+                .Trim('.') + _suffixGenerator.Generate();
     }
 }

--- a/src/SymbolCollector.Core/FatBinaryReader.cs
+++ b/src/SymbolCollector.Core/FatBinaryReader.cs
@@ -16,7 +16,7 @@ namespace SymbolCollector.Core
         public FatHeader Header { get; set; }
         public IEnumerable<string> MachOFiles { get; set; } = Enumerable.Empty<string>();
 
-        internal IEnumerable<string> FilesToDelete = Enumerable.Empty<string>();
+        internal IEnumerable<string> FilesToDelete { get; set; } = Enumerable.Empty<string>();
 
         public void Dispose()
         {

--- a/src/SymbolCollector.Core/ObjectFileParser.cs
+++ b/src/SymbolCollector.Core/ObjectFileParser.cs
@@ -476,7 +476,7 @@ namespace SymbolCollector.Core
             return hash;
         }
 
-        private string? GetFallbackDebugId(byte[] textSection)
+        internal string? GetFallbackDebugId(IReadOnlyList<byte> textSection)
         {
             if (textSection is null)
             {
@@ -484,13 +484,13 @@ namespace SymbolCollector.Core
                 return null;
             }
 
-            if (textSection.Length == 0)
+            if (textSection.Count == 0)
             {
                 _logger.LogWarning(".text section is 0 bytes long.");
                 return null;
             }
 
-            var length = Math.Min(4096, textSection.Length);
+            var length = Math.Min(4096, textSection.Count);
             var uuidSize = 16;
             var hash = new byte[uuidSize];
             for (var i = 0; i < length; i++)

--- a/src/SymbolCollector.Core/ObjectKind.cs
+++ b/src/SymbolCollector.Core/ObjectKind.cs
@@ -66,6 +66,18 @@ namespace SymbolCollector.Core
         FatMachO
     }
 
+    public static class FileFormatExtensions
+    {
+        public static string? ToSymsorterFileFormat(this FileFormat fileFormat) =>
+            fileFormat switch
+            {
+                FileFormat.Elf => "elf",
+                FileFormat.MachO => "macho",
+                FileFormat.FatMachO => null, // not symsorted. Inner files are.
+                _ => null
+            };
+    }
+
     public enum Architecture
     {
         Unknown,
@@ -96,5 +108,17 @@ namespace SymbolCollector.Core
         ArmV7m,
         ArmV7em,
         ArmUnknown
+    }
+
+    public static class ArchitectureExtensions
+    {
+        public static string ToSymsorterArchitecture(this Architecture architecture) =>
+            architecture switch
+            {
+                Architecture.Amd64 => "x86_64",
+                Architecture.Amd64Unknown => "x86_64",
+                // TODO: add other mappings from symbolic
+                var a => a.ToString().ToLower()
+            };
     }
 }

--- a/src/SymbolCollector.Core/Startup.cs
+++ b/src/SymbolCollector.Core/Startup.cs
@@ -88,10 +88,14 @@ namespace SymbolCollector.Core
             services.AddSingleton<ClientMetrics>();
             services.AddSingleton<FatBinaryReader>();
             services.AddSingleton<ClientMetrics>();
+            services.AddSingleton<Symsorter>();
 
             services.AddOptions<SymbolClientOptions>()
                 .Configure<IConfiguration>((o, f) => f.Bind("SymbolClient", o))
                 .Validate(o => o.BaseAddress is {}, "BaseAddress is required.");
+
+            services.AddOptions<SymsorterOptions>()
+                .Configure<IConfiguration>((o, f) => f.Bind("Symsorter", o));
 
             services.AddSingleton<SymbolClientOptions>(c =>
                 c.GetRequiredService<IOptions<SymbolClientOptions>>().Value);

--- a/src/SymbolCollector.Core/SuffixGenerator.cs
+++ b/src/SymbolCollector.Core/SuffixGenerator.cs
@@ -2,7 +2,7 @@ using System;
 using System.Buffers;
 using System.Security.Cryptography;
 
-namespace SymbolCollector.Server
+namespace SymbolCollector.Core
 {
     public class SuffixGenerator : IDisposable
     {

--- a/src/SymbolCollector.Core/SymbolCollector.Core.csproj
+++ b/src/SymbolCollector.Core/SymbolCollector.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SymbolCollector.Core/Symsorter.cs
+++ b/src/SymbolCollector.Core/Symsorter.cs
@@ -1,0 +1,183 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace SymbolCollector.Core
+{
+    public class SymsorterOptions
+    {
+        public bool WriteIndented { get; set; }
+        public bool PrintToStdOut { get; set; } = true;
+    }
+
+    public struct SymsorterParameters
+    {
+        public string Output { get; }
+        public string Prefix { get; }
+        public string BundleId { get; }
+
+        public bool DryRun { get; }
+
+        public SymsorterParameters(
+            string output,
+            string prefix,
+            string bundleId,
+            bool dryRun)
+        {
+            Output = output;
+            Prefix = prefix;
+            BundleId = bundleId;
+            DryRun = dryRun;
+        }
+    }
+
+    public class Symsorter
+    {
+        private readonly SymsorterOptions _options;
+        private readonly ObjectFileParser _objectFileParser;
+        private readonly ILogger<Symsorter> _logger;
+        private readonly JsonSerializerOptions _jsonOptions;
+        private static readonly byte[] _refsFileContent = new byte[0];
+
+        public Symsorter(
+            IOptions<SymsorterOptions> options,
+            ObjectFileParser objectFileParser,
+            ILogger<Symsorter> logger)
+        {
+            _options = options.Value;
+            _objectFileParser = objectFileParser;
+            _logger = logger;
+            _jsonOptions = new JsonSerializerOptions { WriteIndented = _options.WriteIndented };
+        }
+
+        public async Task ProcessBundle(SymsorterParameters parameters, string target, CancellationToken token)
+        {
+            var sortedFilesCount = 0;
+            foreach (var file in Directory.EnumerateFiles(target, "*", SearchOption.AllDirectories))
+            {
+                if (_objectFileParser.TryParse(file, out var result) && result is {})
+                {
+                    if (result is FatMachOFileResult fatMachOFileResult)
+                    {
+                        foreach (var innerFile in fatMachOFileResult.InnerFiles)
+                        {
+                            await SortFile(parameters, innerFile, token);
+                            sortedFilesCount++;
+                        }
+                    }
+                    else
+                    {
+                        await SortFile(parameters, result, token);
+                        sortedFilesCount++;
+                    }
+                }
+            }
+
+            if (_options.PrintToStdOut)
+            {
+                var originalColor = Console.ForegroundColor;
+                Console.ForegroundColor = ConsoleColor.White;
+                Console.Write("\nDone: sorted ");
+                Console.ForegroundColor = ConsoleColor.Yellow;
+                Console.Write(sortedFilesCount);
+                Console.ForegroundColor = ConsoleColor.White;
+                Console.WriteLine(" debug files");
+                Console.ForegroundColor = originalColor;
+            }
+        }
+        public async Task SortFile(
+            SymsorterParameters parameters,
+            ObjectFileResult result,
+            CancellationToken token)
+        {
+            Validate(result);
+
+            var directoryRoot = Path.Combine(parameters.Output, result.UnifiedId[..2], result.UnifiedId[2..]);
+            var destinationObjectFile = Path.Combine(directoryRoot, result.ObjectKind.ToSymsorterFileName());
+            var directoryRefs = Path.Combine(directoryRoot, "refs");
+            _ = Directory.CreateDirectory(directoryRefs);
+
+            _logger.LogDebug("Sorting {file} to {destinationFilePath}",
+                result, destinationObjectFile);
+
+            var metaFile = Path.Combine(directoryRoot, "meta");
+            await using var meta = File.OpenWrite(metaFile);
+            var metaContent = new
+            {
+                name = Path.GetFileName(result.Path),
+                arch = result.Architecture.ToSymsorterArchitecture(),
+                file_format = result.FileFormat.ToSymsorterFileFormat()
+            };
+
+            var metaFileJsonTask = JsonSerializer.SerializeAsync(
+                meta,
+                metaContent, _jsonOptions, token);
+
+            var refsFile = Path.Combine(directoryRefs, parameters.BundleId);
+            var refsFileTask = File.WriteAllBytesAsync(refsFile, _refsFileContent, token);
+
+            if (!parameters.DryRun)
+            {
+                await using var objectFileOutput = File.OpenWrite(destinationObjectFile);
+                await using var objectFileInput = File.OpenRead(result.Path!);
+
+                // TODO: zlib content
+                var objectFileTask = objectFileInput.CopyToAsync(objectFileOutput, token);
+
+                await Task.WhenAll(objectFileTask, metaFileJsonTask, refsFileTask);
+            }
+
+            if (_options.PrintToStdOut)
+            {
+                var originalColor = Console.ForegroundColor;
+                Console.ForegroundColor = ConsoleColor.DarkGray;
+                Console.Write($"{metaContent.name} ");
+                Console.ForegroundColor = ConsoleColor.White;
+                Console.Write("(");
+                Console.ForegroundColor = ConsoleColor.DarkYellow;
+                Console.Write(metaContent.arch);
+                Console.ForegroundColor = ConsoleColor.White;
+                Console.Write(") -> ");
+                Console.ForegroundColor = ConsoleColor.DarkCyan;
+                Console.WriteLine(destinationObjectFile);
+                Console.ForegroundColor = originalColor;
+            }
+        }
+
+        private static void Validate(ObjectFileResult objectFileResult)
+        {
+            if (string.IsNullOrWhiteSpace(objectFileResult.UnifiedId))
+            {
+                throw new ArgumentException("A unified id is required for symbol sorting.", nameof(objectFileResult));
+            }
+
+            if (objectFileResult.UnifiedId.Contains("-"))
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(objectFileResult),
+                    objectFileResult.UnifiedId,
+                    "A unified id can't contain dashes required for symbol sorting.");
+            }
+
+            if (objectFileResult.UnifiedId.Length < 16) // TODO is 16 the absolute min?
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(objectFileResult),
+                    objectFileResult.UnifiedId.Length,
+                    "A valid unified id is require to be at least 16 characters long.");
+            }
+
+            if (string.IsNullOrWhiteSpace(objectFileResult.Path))
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(objectFileResult),
+                    objectFileResult.Path,
+                    "No file path for the object file was provided.");
+            }
+        }
+    }
+}

--- a/src/SymbolCollector.Core/appsettings.json
+++ b/src/SymbolCollector.Core/appsettings.json
@@ -8,6 +8,9 @@
       "/usr/lib/cron/tabs"
     ]
   },
+  "Symsorter": {
+    "WriteIndented": true
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Debug",

--- a/src/SymbolCollector.Server/Startup.cs
+++ b/src/SymbolCollector.Server/Startup.cs
@@ -27,6 +27,7 @@ namespace SymbolCollector.Server
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddSingleton<SuffixGenerator>();
+            services.AddSingleton<BundleIdGenerator>();
 
             // TODO: When replacing this to a real (external storage backed), fix lifetimes below (scoped)
             services.AddSingleton<ISymbolService, InMemorySymbolService>();

--- a/test/SymbolCollector.Core.Tests/BundleIdGeneratorTests.cs
+++ b/test/SymbolCollector.Core.Tests/BundleIdGeneratorTests.cs
@@ -1,0 +1,28 @@
+using Xunit;
+
+namespace SymbolCollector.Core.Tests
+{
+    public class BundleIdGeneratorTests
+    {
+        [Fact]
+        public void CreateBundleId_SameFriendlyName_DifferentBundleIdsWithoutSpacesAndSlashes()
+        {
+            using var suffixGenerator = new SuffixGenerator();
+            var target = new BundleIdGenerator(suffixGenerator);
+
+            var friendlyName = @".this is the // """"
+? * a friendly name";
+            var actual = target.CreateBundleId(friendlyName);
+            Assert.NotEqual(target.CreateBundleId(friendlyName), actual);
+            Assert.False(actual.EndsWith("."));
+            Assert.False(actual.StartsWith("."));
+            Assert.DoesNotContain("/", actual);
+            Assert.DoesNotContain(" ", actual);
+            Assert.DoesNotContain("\"", actual);
+            Assert.DoesNotContain("?", actual);
+            Assert.DoesNotContain("*", actual);
+            Assert.DoesNotContain(@"
+", actual);
+        }
+    }
+}

--- a/test/SymbolCollector.Core.Tests/FatBinaryReaderTest.cs
+++ b/test/SymbolCollector.Core.Tests/FatBinaryReaderTest.cs
@@ -72,12 +72,19 @@ namespace SymbolCollector.Core.Tests
         public void ParseHeader_BufferTooSmall_ReturnsNull(byte[] input) => Assert.Null(FatBinaryReader.ParseHeader(input));
 
         [Fact]
-        public void GetFatArches_()
+        public void GetFatArches_ExpectedFatFilesArchitectures()
         {
             var arches = FatBinaryReader.GetFatArches(_fatMachO, 2).ToList();
             Assert.Equal(2, arches.Count);
             Assert.True(arches[0].Is64Bit());
             Assert.False(arches[1].Is64Bit());
+        }
+
+        [Fact]
+        public void TryLoad_InvalidPath_ReturnsNull()
+        {
+            var target = new FatBinaryReader();
+            Assert.False(target.TryLoad("invalid", out _));
         }
     }
 }

--- a/test/SymbolCollector.Core.Tests/FatMachOTests.cs
+++ b/test/SymbolCollector.Core.Tests/FatMachOTests.cs
@@ -1,0 +1,26 @@
+using System.IO;
+using Xunit;
+
+namespace SymbolCollector.Core.Tests
+{
+    public class FatMachOTests
+    {
+        [Fact]
+        public void Dispose_DefaultArg_FileNotDeleted()
+        {
+            var file = Path.GetTempFileName();
+            var f = new FatMachO {FilesToDelete = new[] { file }};
+            f.Dispose();
+            Assert.True(File.Exists(file));
+            File.Delete(file);
+        }
+        [Fact]
+        public void Dispose_DeleteOnDispose_FileDeleted()
+        {
+            var file = Path.GetTempFileName();
+            var f = new FatMachO(deleteFilesOnDispose: true) { FilesToDelete = new[] { file } };
+            f.Dispose();
+            Assert.False(File.Exists(file));
+        }
+    }
+}

--- a/test/SymbolCollector.Core.Tests/ObjectFileParserTests.cs
+++ b/test/SymbolCollector.Core.Tests/ObjectFileParserTests.cs
@@ -61,8 +61,18 @@ namespace SymbolCollector.Core.Tests
             else
             {
                 AssertObjectFileResult(testCase.Expected, actual!);
+                if (testCase.ExpectedSymsorterFileName is {} name)
+                {
+                    Assert.Equal(name, actual!.ObjectKind.ToSymsorterFileName());
+                }
             }
         }
+
+        [Fact]
+        public void GetFallbackDebugId_NullArg_ReturnsNull() => Assert.Null(_fixture.GetSut().GetFallbackDebugId(null!));
+
+        [Fact]
+        public void GetFallbackDebugId_EmptyArg_ReturnsNull() => Assert.Null(_fixture.GetSut().GetFallbackDebugId(new byte[0]));
 
         private static void AssertObjectFileResult(ObjectFileResult expected, ObjectFileResult actual)
         {

--- a/test/SymbolCollector.Core.Tests/ObjectFileResultTestCases.cs
+++ b/test/SymbolCollector.Core.Tests/ObjectFileResultTestCases.cs
@@ -25,7 +25,8 @@ namespace SymbolCollector.Core.Tests
                     BuildIdType.GnuBuildId,
                     ObjectKind.Library,
                     FileFormat.Elf,
-                    Architecture.X86)
+                    Architecture.X86),
+                ExpectedSymsorterFileName = "executable"
             };
 
             yield return new ObjectFileResultTestCase("TestFiles/libdl.so")
@@ -40,7 +41,8 @@ namespace SymbolCollector.Core.Tests
                     BuildIdType.GnuBuildId,
                     ObjectKind.Library,
                     FileFormat.Elf,
-                    Architecture.X86)
+                    Architecture.X86),
+                ExpectedSymsorterFileName = "executable"
             };
 
             yield return new ObjectFileResultTestCase("TestFiles/System.Net.Security.Native.so")
@@ -55,7 +57,8 @@ namespace SymbolCollector.Core.Tests
                     BuildIdType.GnuBuildId,
                     ObjectKind.Library,
                     FileFormat.Elf,
-                    Architecture.Amd64)
+                    Architecture.Amd64),
+                ExpectedSymsorterFileName = "executable"
             };
 
             yield return new ObjectFileResultTestCase("TestFiles/System.Net.Http.Native.so")
@@ -70,7 +73,8 @@ namespace SymbolCollector.Core.Tests
                     BuildIdType.GnuBuildId,
                     ObjectKind.Library,
                     FileFormat.Elf,
-                    Architecture.Amd64)
+                    Architecture.Amd64),
+                ExpectedSymsorterFileName = "executable"
             };
 
             yield return new ObjectFileResultTestCase("TestFiles/System.Globalization.Native.so")
@@ -85,7 +89,8 @@ namespace SymbolCollector.Core.Tests
                     BuildIdType.GnuBuildId,
                     ObjectKind.Library,
                     FileFormat.Elf,
-                    Architecture.Arm)
+                    Architecture.Arm),
+                ExpectedSymsorterFileName = "executable"
             };
 
             yield return new ObjectFileResultTestCase("TestFiles/libxamarin-app.so")
@@ -100,7 +105,8 @@ namespace SymbolCollector.Core.Tests
                     BuildIdType.GnuBuildId,
                     ObjectKind.Library,
                     FileFormat.Elf,
-                    Architecture.Arm)
+                    Architecture.Arm),
+                ExpectedSymsorterFileName = "executable"
             };
 
             yield return new ObjectFileResultTestCase("TestFiles/libxamarin-app-arm64-v8a.so")
@@ -115,7 +121,8 @@ namespace SymbolCollector.Core.Tests
                     BuildIdType.GnuBuildId,
                     ObjectKind.Debug,
                     FileFormat.Elf,
-                    Architecture.Arm64)
+                    Architecture.Arm64),
+                ExpectedSymsorterFileName = "debuginfo"
             };
 
             yield return new ObjectFileResultTestCase("TestFiles/libqcbassboost.so")
@@ -130,7 +137,8 @@ namespace SymbolCollector.Core.Tests
                     BuildIdType.TextSectionHash,
                     ObjectKind.Library,
                     FileFormat.Elf,
-                    Architecture.Arm)
+                    Architecture.Arm),
+                ExpectedSymsorterFileName = "executable"
             };
 
             yield return new ObjectFileResultTestCase("TestFiles/System.Net.Http.Native.dylib")
@@ -145,7 +153,8 @@ namespace SymbolCollector.Core.Tests
                     BuildIdType.Uuid,
                     ObjectKind.Library,
                     FileFormat.MachO,
-                    Architecture.Amd64)
+                    Architecture.Amd64),
+                ExpectedSymsorterFileName = "executable"
             };
 
             yield return new ObjectFileResultTestCase("TestFiles/libutil.dylib")
@@ -160,7 +169,8 @@ namespace SymbolCollector.Core.Tests
                     BuildIdType.Uuid,
                     ObjectKind.Library,
                     FileFormat.MachO,
-                    Architecture.Amd64)
+                    Architecture.Amd64),
+                ExpectedSymsorterFileName = "executable"
             };
 
             yield return new ObjectFileResultTestCase("TestFiles/libswiftObjectiveC.dylib")
@@ -210,6 +220,7 @@ namespace SymbolCollector.Core.Tests
     public class ObjectFileResultTestCase
     {
         public ObjectFileResult? Expected { get; set; }
+        public string? ExpectedSymsorterFileName { get; set; }
         public string Path { get; }
 
         public ObjectFileResultTestCase(string path) => Path = path;


### PR DESCRIPTION
`SymbolCollect.Console` can sort symbols (and print the same output as symsorter):

<img width="754" alt="image" src="https://user-images.githubusercontent.com/1633368/73135865-6919a280-4015-11ea-967c-aac5e0f48164.png">

TODO: Need to make sure all Arch mappings match.