### PR TITLE
Fix: Mac OSX publish issue

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -55,4 +55,12 @@ for arch in "${archs[@]}"; do
     dotnet publish -c release /p:PublishSingleFile=true --self-contained -r $arch -o publish-$arch
     zip -j symbolcollector-console-$arch.zip publish-$arch/SymbolCollector.Console
 done
+
+# Validate if SymbolCollector is starting on Mac OS X
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    echo "Validating if generated SymbolCollector.Console starts..."
+    cli=./publish-osx-x64/SymbolCollector.Console
+    chmod +x $cli
+    ./$cli --version -h
+fi
 popd

--- a/src/SymbolCollector.Console/SymbolCollector.Console.csproj
+++ b/src/SymbolCollector.Console/SymbolCollector.Console.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
-    <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.20574.7" />
+    <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.21216.1" />
     <ProjectReference Include="..\SymbolCollector.Core\SymbolCollector.Core.csproj" />
   </ItemGroup>
 

--- a/src/SymbolCollector.Console/SymbolCollector.Console.csproj
+++ b/src/SymbolCollector.Console/SymbolCollector.Console.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
-    <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.21216.1" />
+    <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.20574.7" />
     <ProjectReference Include="..\SymbolCollector.Core\SymbolCollector.Core.csproj" />
   </ItemGroup>
 

--- a/src/SymbolCollector.Console/SymbolCollector.Console.csproj
+++ b/src/SymbolCollector.Console/SymbolCollector.Console.csproj
@@ -6,11 +6,12 @@
     <!-- This should be picked up from Directory.Build.props but after adding a dependency to-->
     <!-- System.CommandLine.DragonFruit it will fail to `dotnet run` without it set here:-->
     <NoWarn Condition="'$(Configuration)' == 'Debug'">$(NoWarn);CS1591</NoWarn>
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
-    <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.20574.7" />
+    <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.21216.1" />
     <ProjectReference Include="..\SymbolCollector.Core\SymbolCollector.Core.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
- Updated DragonFruit package. (Was causing problems once the application was packed into a single file)
- Added additional checks to build.sh
- Set IncludeNativeLibrariesForSelfExtract as true for the Console project (see: https://github.com/dotnet/core/issues/5752), this rollbacks the previous behaviour by adding all native libraries to the same package and not outside of it.
Closes #114