### PR TITLE
Don't serialize the cancellation token.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- NotSupportedException when serializing Args([#125](https://github.com/getsentry/symbol-collector/pull/125))
+
 ## 1.5.2
 
 ### Various fixes & improvements

--- a/src/SymbolCollector.Console/Program.cs
+++ b/src/SymbolCollector.Console/Program.cs
@@ -241,7 +241,7 @@ namespace SymbolCollector.Console
                         s.SetTag("server-endpoint", args.ServerEndpoint.AbsoluteUri);
                     }
 
-                    s.Contexts["parameters"] = args;                    
+                    s.Contexts["parameters"] = args;
                 });
             }
 

--- a/src/SymbolCollector.Console/Program.cs
+++ b/src/SymbolCollector.Console/Program.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
@@ -240,7 +241,7 @@ namespace SymbolCollector.Console
                         s.SetTag("server-endpoint", args.ServerEndpoint.AbsoluteUri);
                     }
 
-                    s.Contexts["parameters"] = args;
+                    s.Contexts["parameters"] = args;                    
                 });
             }
 
@@ -296,6 +297,8 @@ namespace SymbolCollector.Console
         public Uri? ServerEndpoint { get; }
         public string UserAgent { get; }
         public bool DryRun { get; }
+
+        [JsonIgnore]
         public CancellationTokenSource Cancellation { get; }
     }
 }


### PR DESCRIPTION
Aims to fix #124

https://github.com/getsentry/symbol-collector/blob/ccbdebaecedfc8ac9244301e564e39c6c2b71caa/src/SymbolCollector.Console/Program.cs#L243
Gets serialized and Args contains a cancelation token that inside has an invalid type that cannot be serialized.
The PR just excludes the cancelation token from being serialized.