### PR TITLE
ref: remove frakenproj

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ TestResult.xml
 **/publish*
 **/*.zip
 packages/
+**/uitest/

--- a/SymbolCollector.sln
+++ b/SymbolCollector.sln
@@ -21,6 +21,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SymbolCollector.Android.Lib
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SymbolCollector.Console.Tests", "test\SymbolCollector.Console.Tests\SymbolCollector.Console.Tests.csproj", "{DF467643-472E-4B46-9D3C-6F71E2D67687}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SymbolCollector.Android.UITests", "test\SymbolCollector.Android.UITests\SymbolCollector.Android.UITests.csproj", "{1A8112A2-71A4-49EC-BAC3-CFAE3B488717}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -139,6 +141,18 @@ Global
 		{DF467643-472E-4B46-9D3C-6F71E2D67687}.Release|x64.Build.0 = Release|Any CPU
 		{DF467643-472E-4B46-9D3C-6F71E2D67687}.Release|x86.ActiveCfg = Release|Any CPU
 		{DF467643-472E-4B46-9D3C-6F71E2D67687}.Release|x86.Build.0 = Release|Any CPU
+		{1A8112A2-71A4-49EC-BAC3-CFAE3B488717}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1A8112A2-71A4-49EC-BAC3-CFAE3B488717}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1A8112A2-71A4-49EC-BAC3-CFAE3B488717}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1A8112A2-71A4-49EC-BAC3-CFAE3B488717}.Debug|x64.Build.0 = Debug|Any CPU
+		{1A8112A2-71A4-49EC-BAC3-CFAE3B488717}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1A8112A2-71A4-49EC-BAC3-CFAE3B488717}.Debug|x86.Build.0 = Debug|Any CPU
+		{1A8112A2-71A4-49EC-BAC3-CFAE3B488717}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1A8112A2-71A4-49EC-BAC3-CFAE3B488717}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1A8112A2-71A4-49EC-BAC3-CFAE3B488717}.Release|x64.ActiveCfg = Release|Any CPU
+		{1A8112A2-71A4-49EC-BAC3-CFAE3B488717}.Release|x64.Build.0 = Release|Any CPU
+		{1A8112A2-71A4-49EC-BAC3-CFAE3B488717}.Release|x86.ActiveCfg = Release|Any CPU
+		{1A8112A2-71A4-49EC-BAC3-CFAE3B488717}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/run.sh
+++ b/run.sh
@@ -20,7 +20,7 @@ pushd test/SymbolCollector.Android.UITests/
 dotnet build -c Release -o uitest
 
 pushd uitest/
-cp ../../../../$apk_path .
+cp ../../../$apk_path .
 for barch_number in $(seq 1 1 $appcenter_batch_count); do
 	echo Running Batch \#$barch_number
     appcenter test run uitest --app $SC_APP \

--- a/run.sh
+++ b/run.sh
@@ -17,14 +17,15 @@ dotnet publish -c Release
 popd
 
 pushd test/SymbolCollector.Android.UITests/
-msbuild /restore /p:Configuration=Release /t:Build
+dotnet build -c Release -o bin/Release
 
 pushd bin/Release/
+cp ../../../../$apk_path .
 for barch_number in $(seq 1 1 $appcenter_batch_count); do
 	echo Running Batch \#$barch_number
     appcenter test run uitest --app $SC_APP \
         --devices $SC_DEVICE_SET \
-        --app-path  ../../../../$apk_path \
+        --app-path  *.apk \
         --test-series "master" \
         --locale "en_US" \
         --build-dir . \

--- a/run.sh
+++ b/run.sh
@@ -5,7 +5,7 @@ set -e
 # Builds the app and the UI tests in release mode and schedule it on appcenter
 
 export appcenter_batch_count=${appcenter_batch_count:-1}
-export apk_path=src/SymbolCollector.Android/bin/Release/net7.0-android/publish/io.sentry.symbolcollector.android-Signed.apk
+export apk_path=src/SymbolCollector.Android/uitest/io.sentry.symbolcollector.android-Signed.apk
 rm $apk_path && echo deleted apk || echo apk not there
 
 # Always a source of issues trying to find the Android SDK:
@@ -13,13 +13,13 @@ rm $apk_path && echo deleted apk || echo apk not there
 rm ~/.config/xbuild/monodroid-config.xml || echo monodroid config didnt exist
 
 pushd src/SymbolCollector.Android/
-dotnet publish -c Release
+dotnet publish -c Release -o uitest
 popd
 
 pushd test/SymbolCollector.Android.UITests/
-dotnet build -c Release -o bin/Release
+dotnet build -c Release -o uitest
 
-pushd bin/Release/
+pushd uitest/
 cp ../../../../$apk_path .
 for barch_number in $(seq 1 1 $appcenter_batch_count); do
 	echo Running Batch \#$barch_number
@@ -30,5 +30,5 @@ for barch_number in $(seq 1 1 $appcenter_batch_count); do
         --locale "en_US" \
         --build-dir . \
         --async \
-        --uitest-tools-dir ~/.nuget/packages/xamarin.uitest/3.2.8/tools/
+        --uitest-tools-dir .
 done

--- a/test/SymbolCollector.Android.UITests/SymbolCollector.Android.UITests.csproj
+++ b/test/SymbolCollector.Android.UITests/SymbolCollector.Android.UITests.csproj
@@ -1,47 +1,15 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{48BB7372-FB0A-46DE-B66C-FDE208EB0508}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <RootNamespace>SymbolCollector.Android.UITests</RootNamespace>
-    <AssemblyName>SymbolCollector.Android.UITests</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFramework>net48</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <NoWarn></NoWarn>
-    <LangVersion>Default</LangVersion>
-    <Nullable></Nullable>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <Optimize>true</Optimize>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <OutputPath>bin\Release</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <LangVersion>Default</LangVersion>
-    <Nullable></Nullable>
-  </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="System" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Tests.cs" />
-  </ItemGroup>
-  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="Xamarin.UITest" Version="3.2.8" />
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+
 </Project>


### PR DESCRIPTION
Got an M1 and had to setup the project. Not really running Mono anymore so had to work around UITest still being full framework.

It required a symlink locally: `ln -s /opt/homebrew/Cellar/mono/6.12.0.182/bin/mono-sgen /Library/Frameworks/Mono.framework/Commands/mono`

Seems like the UI Test bits have that path hard coded.