### PR TITLE
cd: add GoCD deployment pipeline

### DIFF
--- a/.github/workflows/lint-pipelines.sh
+++ b/.github/workflows/lint-pipelines.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# gocd-cli does not catch all errors, but does catch some simple issues.
+# A better solution may be: https://github.com/GaneshSPatil/gocd-mergeable
+
+echo "GoCD YAML Linting"
+
+find "gocd" -name "*.yaml" -type f -print0 | \
+  xargs -0 -I'{}' bash -c 'printf  "\n🔎 Linting {}\n\t" && gocd-cli configrepo syntax --yaml --raw "{}"'

--- a/.github/workflows/lint-pipelines.yml
+++ b/.github/workflows/lint-pipelines.yml
@@ -1,0 +1,20 @@
+name: Lint Deployment Pipelines
+
+on:
+    pull_request:
+    push:
+        branches: [main, test-me-*]
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+    cancel-in-progress: true
+
+jobs:
+    lint:
+        name: Lint GoCD Pipelines
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c  # v3
+            - uses: getsentry/action-setup-gocd-cli@2f7943ce1a380dea121fd6338a60dc9aabf8e7f1  # v1.0.1
+            - name: Lint Pipelines with gocd-cli
+              run: ./.github/workflows/lint-pipelines.sh

--- a/gocd/pipelines/symbol-collector.yaml
+++ b/gocd/pipelines/symbol-collector.yaml
@@ -16,7 +16,7 @@ pipelines:
             symbol-collector_repo:
                 git: git@github.com:getsentry/symbol-collector.git
                 shallow_clone: true
-                branch: master
+                branch: main
                 destination: symbol-collector
         stages:
             - checks:

--- a/gocd/pipelines/symbol-collector.yaml
+++ b/gocd/pipelines/symbol-collector.yaml
@@ -1,0 +1,57 @@
+# More information on gocd-flavor YAML can be found here:
+# - https://github.com/tomzo/gocd-yaml-config-plugin#pipeline
+# - https://www.notion.so/sentry/GoCD-New-Service-Quickstart-6d8db7a6964049b3b0e78b8a4b52e25d
+format_version: 10
+pipelines:
+    deploy-symbol-collector:
+        environment_variables:
+            GCP_PROJECT: internal-sentry
+            GKE_CLUSTER: zdpwkxst
+            GKE_REGION: us-central1
+            GKE_CLUSTER_ZONE: b
+            GKE_BASTION_ZONE: b
+        group: symbol-collector
+        lock_behavior: unlockWhenFinished
+        materials:
+            symbol-collector_repo:
+                git: git@github.com:getsentry/symbol-collector.git
+                shallow_clone: true
+                branch: master
+                destination: symbol-collector
+        stages:
+            - checks:
+                  approval:
+                      type: manual
+                  fetch_materials: true
+                  jobs:
+                      checks:
+                          environment_variables:
+                              # Required for checkruns.
+                              GITHUB_TOKEN: "{{SECRET:[devinfra-github][token]}}"
+                          timeout: 1200
+                          elastic_profile_id: symbol-collector
+                          tasks:
+                              - script: |
+                                    /devinfra/scripts/checks/githubactions/checkruns.py \
+                                    getsentry/symbol-collector \
+                                    ${GO_REVISION_SYMBOL_COLLECTOR_REPO} \
+                                    macos-latest \
+                                    windows-latest
+                              - script: |
+                                    /devinfra/scripts/checks/googlecloud/checkcloudbuild.py \
+                                    ${GO_REVISION_SYMBOL_COLLECTOR_REPO} \
+                                    sentryio \
+                                    "us.gcr.io/sentryio/symbol-collector"
+            - deploy:
+                  fetch_materials: true
+                  jobs:
+                      deploy:
+                          timeout: 1200
+                          elastic_profile_id: symbol-collector
+                          tasks:
+                              - script: |
+                                    /devinfra/scripts/k8s/k8stunnel \
+                                    && /devinfra/scripts/k8s/k8sdeploy.py \
+                                    --label-selector="service=symbol-collector" \
+                                    --image="us.gcr.io/sentryio/symbol-collector:${GO_REVISION_SYMBOL_COLLECTOR_REPO}" \
+                                    --container-name="symbol-collector"


### PR DESCRIPTION
This adds deployment configurations for GoCD, the new internal continuous deployment tool. Please refer to the [Freight Migration Guide](https://www.notion.so/sentry/Freight-Migration-Guide-2bd47bb683254077ad31e7ad625345ae) for info on how to coordinate GoCD deploys during this transitional phase.