### PR TITLE
fix: fat binary reader leaking temp files

### DIFF
--- a/src/SymbolCollector.Core/FatBinaryReader.cs
+++ b/src/SymbolCollector.Core/FatBinaryReader.cs
@@ -67,11 +67,11 @@ namespace SymbolCollector.Core
             }
 
             var filesToDelete = new List<string>();
-            fatMachO = new FatMachO()
+            fatMachO = new FatMachO(true)
             {
                 Header = header.Value,
                 FilesToDelete = filesToDelete,
-                MachOFiles = GetFatArches(bytes, (int) header.Value.FatArchCount)
+                MachOFiles = GetFatArches(bytes, (int)header.Value.FatArchCount)
                     .Select(arch =>
                     {
                         // TODO: This needs to change. Current Mach-O lib only reads from disk
@@ -102,7 +102,7 @@ namespace SymbolCollector.Core
                 var itemOffset = i;
                 yield return new FatArch
                 {
-                    CpuType  = Get(),
+                    CpuType = Get(),
                     CpuSubType = Get(),
                     StartOffset = Get(),
                     Size = Get(),


### PR DESCRIPTION
found this when debugging CI failures in https://github.com/getsentry/sentry-dart/pull/1673

The constructor argument decides whether the files should be removed on dispose.