### PR TITLE
PublishAot on console app

### DIFF
--- a/src/SymbolCollector.Console/SymbolCollector.Console.csproj
+++ b/src/SymbolCollector.Console/SymbolCollector.Console.csproj
@@ -10,6 +10,7 @@
     <NoWarn>1591</NoWarn>
     <!-- For symbol uploading -->
     <SentryProject>symbol-collector-console</SentryProject>
+    <PublishAot>true</PublishAot>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This will make craft builds faster. AOT has faster startup time.
And it'll help us dogfood out AOT/native crash support added on Sentry SDK for .NET 4.0.0

TODO:
- [ ] test this on mac/linux
- [ ] cause crash test minidump upload
- [ ] test symbol upload


cc @bitsandfoxes 
