### PR TITLE
sentry metrics on server

### DIFF
--- a/src/SymbolCollector.Android.Library/Host.cs
+++ b/src/SymbolCollector.Android.Library/Host.cs
@@ -34,6 +34,12 @@ public class Host
 
             o.TracesSampleRate = 1.0;
             o.Debug = true;
+
+            o.ExperimentalMetrics = new ExperimentalMetricsOptions
+            {
+                EnableCodeLocations = true
+            };
+
 #if ANDROID
             o.Android.LogCatIntegration = Sentry.Android.LogCatIntegrationType.All;
             // Bindings to the native SDK

--- a/src/SymbolCollector.Server/ProxyMetricsPublisher.cs
+++ b/src/SymbolCollector.Server/ProxyMetricsPublisher.cs
@@ -1,0 +1,92 @@
+namespace SymbolCollector.Server;
+
+public class ProxyMetricsPublisher(
+    // going through property to observe a change in the instance on the client.
+    // ReSharper disable once SuggestBaseTypeForParameterInConstructor
+    StatsDMetricsPublisher metricsPublisherImplementation,
+    // ReSharper disable once SuggestBaseTypeForParameterInConstructor
+    SentryMetricsPublisher metricsPublisherImplementation2)
+    : IMetricsPublisher
+{
+    public IDisposable BeginOpenBatch()
+    {
+        return new DisposableProxy(metricsPublisherImplementation.BeginOpenBatch(),
+            metricsPublisherImplementation2.BeginOpenBatch());
+    }
+
+    public IDisposable BeginCloseBatch()
+    {
+        return new DisposableProxy(metricsPublisherImplementation.BeginCloseBatch(),
+            metricsPublisherImplementation2.BeginCloseBatch());
+    }
+
+    public IDisposable BeginSymbolMissingCheck()
+    {
+        return new DisposableProxy(metricsPublisherImplementation.BeginSymbolMissingCheck(),
+            metricsPublisherImplementation2.BeginSymbolMissingCheck());
+    }
+
+    public IDisposable BeginUploadSymbol()
+    {
+        return new DisposableProxy(metricsPublisherImplementation.BeginUploadSymbol(),
+            metricsPublisherImplementation2.BeginUploadSymbol());
+    }
+
+    public void SymbolCheckExists()
+    {
+        metricsPublisherImplementation.SymbolCheckExists();
+        metricsPublisherImplementation2.SymbolCheckExists();
+    }
+
+    public void SymbolCheckMissing()
+    {
+        metricsPublisherImplementation.SymbolCheckMissing();
+        metricsPublisherImplementation2.SymbolCheckMissing();
+    }
+
+    public void FileStored(long size)
+    {
+        metricsPublisherImplementation.FileStored(size);
+        metricsPublisherImplementation2.FileStored(size);
+    }
+
+    public void FileInvalid()
+    {
+        metricsPublisherImplementation.FileInvalid();
+        metricsPublisherImplementation2.FileInvalid();
+    }
+
+    public void FileKnown()
+    {
+        metricsPublisherImplementation.FileKnown();
+        metricsPublisherImplementation2.FileKnown();
+    }
+
+    public void DebugIdHashConflict()
+    {
+        metricsPublisherImplementation.DebugIdHashConflict();
+        metricsPublisherImplementation2.DebugIdHashConflict();
+    }
+
+    public void SentryEventProcessed()
+    {
+        metricsPublisherImplementation.SentryEventProcessed();
+        metricsPublisherImplementation2.SentryEventProcessed();
+    }
+
+    public IDisposable BeginGcsBatchUpload()
+    {
+        return new DisposableProxy(metricsPublisherImplementation.BeginGcsBatchUpload(),
+            metricsPublisherImplementation2.BeginGcsBatchUpload());
+    }
+
+    private class DisposableProxy(IDisposable disposableImplementation, IDisposable disposableImplementation2)
+        : IDisposable
+    {
+        public void Dispose()
+        {
+            disposableImplementation.Dispose();
+            disposableImplementation2.Dispose();
+        }
+    }
+}

--- a/src/SymbolCollector.Server/SentryMetricsPublisher.cs
+++ b/src/SymbolCollector.Server/SentryMetricsPublisher.cs
@@ -1,0 +1,82 @@
+using System.Diagnostics;
+using Sentry;
+
+namespace SymbolCollector.Server;
+
+public class SentryMetricsPublisher(ISentryClient sentryClient) : IMetricsPublisher
+{
+    private const string BatchOpenCurrentCount = "batch-current";
+
+    private class Timer(IMetricAggregator metricAggregator, string key, Action? onDispose = null) : IDisposable
+    {
+        private readonly Stopwatch _stopwatch = Stopwatch.StartNew();
+
+        public void Dispose()
+        {
+            _stopwatch.Stop();
+            metricAggregator.Timing(key, _stopwatch.ElapsedMilliseconds, MeasurementUnit.Duration.Millisecond);
+            onDispose?.Invoke();
+        }
+    }
+    public IDisposable BeginOpenBatch()
+    {
+        sentryClient.Metrics.Gauge(BatchOpenCurrentCount);
+        return new Timer(sentryClient.Metrics,BatchOpenCurrentCount);
+    }
+
+    public IDisposable BeginCloseBatch()
+    {
+        return new Timer(sentryClient.Metrics,"batch-close",
+            () => sentryClient.Metrics.Gauge(BatchOpenCurrentCount, -1));
+    }
+
+    public IDisposable BeginSymbolMissingCheck()
+    {
+        return new Timer(sentryClient.Metrics,"symbol-check");
+    }
+
+    public IDisposable BeginUploadSymbol()
+    {
+        return new Timer(sentryClient.Metrics,"symbol-upload");
+    }
+
+    public void SymbolCheckExists()
+    {
+        sentryClient.Metrics.Increment("symbol-check-exists");
+    }
+
+    public void SymbolCheckMissing()
+    {
+        sentryClient.Metrics.Increment("symbol-check-missing");
+    }
+
+    public void FileStored(long size)
+    {
+        sentryClient.Metrics.Increment("file-stored-bytes", size, MeasurementUnit.Custom("bytes"));
+    }
+
+    public void FileInvalid()
+    {
+        sentryClient.Metrics.Increment("file-invalid");
+    }
+
+    public void FileKnown()
+    {
+        sentryClient.Metrics.Increment("file-known");
+    }
+
+    public void DebugIdHashConflict()
+    {
+        sentryClient.Metrics.Increment("debug-id-hash-conflict");
+    }
+
+    public void SentryEventProcessed()
+    {
+        sentryClient.Metrics.Increment("sentry-event-processed");
+    }
+
+    public IDisposable BeginGcsBatchUpload()
+    {
+        return new Timer(sentryClient.Metrics, "gcs-upload");
+    }
+}

--- a/src/SymbolCollector.Server/Startup.cs
+++ b/src/SymbolCollector.Server/Startup.cs
@@ -75,9 +75,16 @@ public class Startup
             .AddJsonOptions(options =>
                 options.JsonSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.CamelCase);
 
-        services.AddSingleton<ISymbolServiceMetrics, MetricsPublisher>();
-        services.AddSingleton<ISymbolControllerMetrics, MetricsPublisher>();
-        services.AddSingleton<IMetricsPublisher, MetricsPublisher>();
+        services.AddSingleton<ISymbolServiceMetrics, ProxyMetricsPublisher>();
+        services.AddSingleton<ISymbolControllerMetrics, ProxyMetricsPublisher>();
+        services.AddSingleton<IMetricsPublisher, ProxyMetricsPublisher>();
+
+        services.AddSingleton<StatsDMetricsPublisher>();
+        services.AddSingleton<SentryMetricsPublisher>();
+
+        services.AddSingleton<ProxyMetricsPublisher>(c => new ProxyMetricsPublisher(
+            c.GetRequiredService<StatsDMetricsPublisher>(),
+            c.GetRequiredService<SentryMetricsPublisher>()));
 
         services.AddOptions<StatsDOptions>()
             .Configure<IConfiguration>((o, c) => c.Bind("StatsD", o))

--- a/src/SymbolCollector.Server/StatsDMetricsPublisher.cs
+++ b/src/SymbolCollector.Server/StatsDMetricsPublisher.cs
@@ -2,12 +2,12 @@ using JustEat.StatsD;
 
 namespace SymbolCollector.Server;
 
-public class MetricsPublisher : IMetricsPublisher
+public class StatsDMetricsPublisher : IMetricsPublisher
 {
     private readonly IStatsDPublisher _publisher;
     private const string BatchOpenCurrentCount = "batch-current";
 
-    public MetricsPublisher(IStatsDPublisher publisher) => _publisher = publisher;
+    public StatsDMetricsPublisher(IStatsDPublisher publisher) => _publisher = publisher;
 
     public void DebugIdHashConflict() => _publisher.Increment("debug-id-hash-conflict");
 

--- a/src/SymbolCollector.Server/appsettings.json
+++ b/src/SymbolCollector.Server/appsettings.json
@@ -24,7 +24,7 @@
     "AttachStackTrace": true,
     "Debug": true,
     "DiagnosticLevel": "Info",
-    "Dsn": "https://2262a4fa0a6d409c848908ec90c3c5b4@sentry.io/1886021",
+    "Dsn": "https://2262a4fa0a6d409c848908ec90c3c5b4@o1.ingest.sentry.io/1886021",
     "TracesSampleRate": 1.0,
     "DefaultTags": {
       "app": "SymbolCollector.Server"
@@ -57,7 +57,7 @@
         "Name": "Sentry",
         "Args": {
           "Debug": true,
-          "Dsn": "https://2262a4fa0a6d409c848908ec90c3c5b4@sentry.io/1886021",
+          "Dsn": "https://2262a4fa0a6d409c848908ec90c3c5b4@o1.ingest.sentry.io/1886021",
           "MinimumBreadcrumbLevel": "Debug",
           "MinimumEventLevel": "Error"
         }


### PR DESCRIPTION
Resolves: https://github.com/getsentry/symbol-collector/issues/175

Looking at adding also client metrics but it's coming out as `0` for all values:

![image](https://github.com/getsentry/symbol-collector/assets/1633368/4fa6882c-af94-49fd-b40a-f178572c746d)
They are sent (keys show up in Sentry):
![image](https://github.com/getsentry/symbol-collector/assets/1633368/34ea2b27-2b50-45cd-b07f-4a3d1db609b4)

Debug logs:
```
2024-01-18 20:32:17.661 22145-22264 DOTNET                  io.sentry.symbolcollector.android    I    Debug: Flushing metrics for bucket 1705627930
2024-01-18 20:32:17.661 22145-22264 DOTNET                  io.sentry.symbolcollector.android    I    Debug: Capturing metrics.
2024-01-18 20:32:17.662 22145-22264 DOTNET                  io.sentry.symbolcollector.android    I    Debug: Enqueuing envelope
2024-01-18 20:32:17.662 22145-22264 DOTNET                  io.sentry.symbolcollector.android    I     Info: Envelope queued up: ''
2024-01-18 20:32:17.662 22145-22264 DOTNET                  io.sentry.symbolcollector.android    I    Debug: Metric flushed for bucket 1705627930
2024-01-18 20:32:17.662 22145-22264 DOTNET                  io.sentry.symbolcollector.android    I    Debug: Flushing metrics for bucket 1705627920
2024-01-18 20:32:17.662 22145-22264 DOTNET                  io.sentry.symbolcollector.android    I    Debug: Capturing metrics.
2024-01-18 20:32:17.662 22145-22264 DOTNET                  io.sentry.symbolcollector.android    I    Debug: Enqueuing envelope
2024-01-18 20:32:17.668 22145-22264 DOTNET                  io.sentry.symbolcollector.android    I     Info: Envelope queued up: ''
2024-01-18 20:32:17.669 22145-22264 DOTNET                  io.sentry.symbolcollector.android    I    Debug: Metric flushed for bucket 1705627920
```


