### PR TITLE
Added Sentry auth token on CI Windows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,6 +42,8 @@ jobs:
 
       - name: Run batch build script
         if: matrix.os == 'windows-latest'
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         shell: cmd
         run: build.cmd
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,9 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest]
-        # https://github.com/getsentry/symbol-collector/pull/186#issuecomment-1997414311
-        # os: [windows-latest, macos-latest, ubuntu-latest]
+        os: [windows-latest, macos-latest, ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,6 +6,10 @@ on:
       - release/*
 
   pull_request:
+
+env:
+  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
 jobs:
   build:
     name: ${{ matrix.os }}
@@ -40,15 +44,11 @@ jobs:
 
       - name: Run batch build script
         if: matrix.os == 'windows-latest'
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         shell: cmd
         run: build.cmd
 
       - name: Run bash build script
         if: matrix.os != 'windows-latest'
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: ./build.sh
 
       - name: Publish coverage report


### PR DESCRIPTION
Sentry CLI now complains when the auth token is missing: https://github.com/getsentry/sentry-cli/pull/1951
Fixes https://github.com/getsentry/sentry-dotnet/issues/3224, https://github.com/getsentry/symbol-collector/issues/187