### PR TITLE
all-repos: update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,7 +55,7 @@ jobs:
         uses: codecov/codecov-action@v3
 
       - name: Archive Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: matrix.os == 'macos-latest'
         with:
           name: ${{ github.sha }}


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos