### PR TITLE
enable sentry profiling

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.0",
+    "rollForward": "latestMinor"
+  }
+}

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -8,6 +8,7 @@
     <PackageVersion Include="Sentry.Extensions.Logging" Version="$(SentryVersion)" />
     <PackageVersion Include="Sentry.AspNetCore" Version="$(SentryVersion)" />
     <PackageVersion Include="Sentry.Serilog" Version="$(SentryVersion)" />
+    <PackageVersion Include="Sentry.Profiling" Version="$(SentryVersion)" />
     <PackageVersion Include="Google.Cloud.Storage.V1" Version="4.2.0" />
     <PackageVersion Include="Serilog.AspNetCore" Version="6.1.0" />
     <PackageVersion Include="Serilog.Settings.Configuration" Version="3.4.0" />

--- a/src/SymbolCollector.Console/Program.cs
+++ b/src/SymbolCollector.Console/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Polly.Extensions.Http;
 using Sentry.Protocol;
+using Sentry.Profiling;
 using SymbolCollector.Core;
 using static System.Console;
 

--- a/src/SymbolCollector.Console/Program.cs
+++ b/src/SymbolCollector.Console/Program.cs
@@ -230,7 +230,11 @@ internal class Program
             o.AutoSessionTracking = true;
 
             o.TracesSampleRate = 1.0;
-            o.ProfilesSampleRate = 0.0;
+            o.ProfilesSampleRate = 1.0;
+
+            o.AddIntegration(new ProfilingIntegration(
+                // Block up to 2 seconds to get profiling started before running the app
+                TimeSpan.FromSeconds(2)));
 
             o.AddExceptionFilterForType<OperationCanceledException>();
         });

--- a/src/SymbolCollector.Console/SymbolCollector.Console.csproj
+++ b/src/SymbolCollector.Console/SymbolCollector.Console.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Sentry.Profiling" />
     <PackageReference Include="System.CommandLine.DragonFruit" />
   </ItemGroup>
 

--- a/src/SymbolCollector.Server/Program.cs
+++ b/src/SymbolCollector.Server/Program.cs
@@ -1,5 +1,7 @@
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Serilog;
+using Sentry;
+using Sentry.Profiling;
 using SystemEnvironment = System.Environment;
 
 namespace SymbolCollector.Server;
@@ -70,6 +72,10 @@ public class Program
                 webBuilder.UseSentry(o =>
                 {
                     o.Dsn = "https://2262a4fa0a6d409c848908ec90c3c5b4@sentry.io/1886021";
+
+                    o.AddIntegration(new ProfilingIntegration(
+                        // Block up to 2 seconds to get profiling started before running the app
+                        TimeSpan.FromSeconds(2)));
 
                     o.AddExceptionFilterForType<OperationCanceledException>();
                     o.MinimumBreadcrumbLevel = LogLevel.Debug;

--- a/src/SymbolCollector.Server/SymbolCollector.Server.csproj
+++ b/src/SymbolCollector.Server/SymbolCollector.Server.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Sentry.AspNetCore" />
     <PackageReference Include="Sentry.Serilog" />
+    <PackageReference Include="Sentry.Profiling" />
     <PackageReference Include="Google.Cloud.Storage.V1" />
     <PackageReference Include="Serilog.AspNetCore" />
     <PackageReference Include="Serilog.Settings.Configuration" />

--- a/src/SymbolCollector.Server/appsettings.Development.json
+++ b/src/SymbolCollector.Server/appsettings.Development.json
@@ -6,7 +6,7 @@
   },
   "Sentry": {
     "TracesSampleRate": 1.0,
-    "ProfilesSampleRate": 0.0
+    "ProfilesSampleRate": 1.0
   },
   "GoogleCloud": {
     "JsonCredentialParameters": {

--- a/src/SymbolCollector.Server/appsettings.json
+++ b/src/SymbolCollector.Server/appsettings.json
@@ -26,7 +26,7 @@
     "DiagnosticLevel": "Info",
     "Dsn": "https://2262a4fa0a6d409c848908ec90c3c5b4@o1.ingest.sentry.io/1886021",
     "TracesSampleRate": 1.0,
-    "ProfilesSampleRate": 0.0,
+    "ProfilesSampleRate": 0.25,
     "DefaultTags": {
       "app": "SymbolCollector.Server"
     }


### PR DESCRIPTION
Latest release of the Sentry SDK for .NET has a fix that avoids ever growing memory:
* https://github.com/dotnet/runtime/issues/105132