### PR TITLE
fix(security): allow dynamic GCP credentials

### DIFF
--- a/src/SymbolCollector.Server/Startup.cs
+++ b/src/SymbolCollector.Server/Startup.cs
@@ -63,9 +63,15 @@ public class Startup
                     jsonCredentials.PrivateKey = SmokeTest.SamplePrivateKey;
                 }
 
-                var json = JsonConvert.SerializeObject(jsonCredentials, Formatting.Indented);
-                var credentials = GoogleCredential.FromJson(json);
-                g.Credential = credentials;
+                if (string.IsNullOrWhiteSpace(jsonCredentials?.PrivateKey))
+                {
+                    g.Credential = GoogleCredential.GetApplicationDefault();
+                }
+                else
+                {
+                    var json = JsonConvert.SerializeObject(jsonCredentials, Formatting.Indented);
+                    g.Credential = GoogleCredential.FromJson(json);
+                }
             })
             .Validate(o => !string.IsNullOrWhiteSpace(o.BucketName), "The GCS Bucket name is required.");
 


### PR DESCRIPTION
This is a more secure approach of getting access to GCP resources:
https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity#what_is

This will allow us to get rid of static credentials `GoogleCloud__JsonCredentialParameters__*` from production. At the same time, we keep the option of having static credentials, for local development purposes.