### PR TITLE
ref(gocd): Cutting over to check_cloudbuild.py

### DIFF
--- a/gocd/pipelines/symbol-collector.yaml
+++ b/gocd/pipelines/symbol-collector.yaml
@@ -38,10 +38,12 @@ pipelines:
                                     macos-latest \
                                     windows-latest
                               - script: |
-                                    /devinfra/scripts/checks/googlecloud/checkcloudbuild.py \
-                                    ${GO_REVISION_SYMBOL_COLLECTOR_REPO} \
+                                    /devinfra/scripts/checks/googlecloud/check_cloudbuild.py \
                                     sentryio \
-                                    "us-central1-docker.pkg.dev/sentryio/symbol-collector/image"
+                                    symbol-collector \
+                                    symbol-collector-push-to-any-branch \
+                                    ${GO_REVISION_SYMBOL_COLLECTOR_REPO} \
+                                    main
             - deploy:
                   fetch_materials: true
                   jobs:


### PR DESCRIPTION
Cutting over to the new check_cloudbuild script that doesn't rely on images anymore and instead relies on repo_name, trigger_name, sha, and branch_name.
https://linear.app/getsentry/issue/DI-634/update-getsentrysymbol-collector-to-use-new-script