### PR TITLE
bump sentry 5.9.0

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <SentryVersion>5.0.1</SentryVersion>
+    <SentryVersion>5.9.0</SentryVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Sentry.Extensions.Logging" Version="$(SentryVersion)" />


### PR DESCRIPTION
Has a fix for line numbers:
* https://github.com/getsentry/sentry-dotnet/pull/4221