### PR TITLE
Use a single HTTP client instance

### DIFF
--- a/src/SymbolCollector.Android.Library/Host.cs
+++ b/src/SymbolCollector.Android.Library/Host.cs
@@ -36,7 +36,7 @@ public class Host
     /// <summary>
     /// Initializes <see cref="IHost"/> with Sentry monitoring.
     /// </summary>
-    public static IHost Init(Context context, string dsn, SentryTraceHeader? sentryTrace = null)
+    public static IHost Init(Context context, string dsn, string? sentryTrace = null)
     {
         SentrySdk.Init(o =>
         {
@@ -83,10 +83,12 @@ public class Host
                     ? null
                     : breadcrumb);
         });
-        var tran = sentryTrace is null
-            ? SentrySdk.StartTransaction("AppStart", "activity.load")
-            // TODO: Can we get away with 'new ()'?
-            : SentrySdk.StartTransaction("AppStart", "activity.load", sentryTrace);
+
+        var tran = sentryTrace is not null
+                   && SentryTraceHeader.Parse(sentryTrace) is { } trace
+                   && trace.TraceId != SentryId.Empty
+            ? SentrySdk.StartTransaction("AppStart", "activity.load", trace)
+            : SentrySdk.StartTransaction("AppStart", "activity.load");
 
         SentrySdk.ConfigureScope(s =>
         {

--- a/src/SymbolCollector.Android/MainActivity.cs
+++ b/src/SymbolCollector.Android/MainActivity.cs
@@ -31,7 +31,7 @@ public class MainActivity : Activity
         _friendlyName = $"Android:{Build.Manufacturer}-{Build.CpuAbi}-{Build.Model}";
 #pragma warning restore 618
         _host = Host.Init(this, "https://656e2e78d37d4511a4ea2cb3602e7a65@sentry.io/5953206",
-            SentryTraceHeader.Parse(Intent?.GetStringExtra("sentryTrace") ?? ""));
+            Intent?.GetStringExtra("sentryTrace"));
         _serviceProvider = _host.Services;
 
         // It's set in Host.Init above

--- a/src/SymbolCollector.Runner/Program.cs
+++ b/src/SymbolCollector.Runner/Program.cs
@@ -7,12 +7,10 @@ Console.WriteLine("Starting runner...");
 const string appName = "SymbolCollector.apk";
 const string appPackage = "io.sentry.symbolcollector.android";
 const string filePath = $"src/SymbolCollector.Android/bin/Release/net9.0-android/{appPackage}-Signed.apk";
-// const string filePath = $"../../../../../src/SymbolCollector.Android/bin/Release/net9.0-android/io.sentry.symbolcollector.android-Signed.apk";
 
 SentrySdk.Init(options =>
 {
-    // options.Dsn = "https://ea58a7607ff1b39433af3a6c10365925@o1.ingest.us.sentry.io/4509420348964864";
-    options.Dsn = "";
+    options.Dsn = "https://ea58a7607ff1b39433af3a6c10365925@o1.ingest.us.sentry.io/4509420348964864";
     options.Debug = false;
     options.AutoSessionTracking = true;
     options.TracesSampleRate = 1.0;
@@ -32,8 +30,6 @@ try
         var span = transaction.StartChild("appium.upload-apk", "uploading apk to saucelabs");
         var buildId = await client.UploadApkAsync(filePath, appName);
         span.Finish();
-        // Run on this specific app
-        // app = $"storage:dd81a803-855f-4b5f-884c-55ee3caafa59";
         app = $"storage:{buildId}";
     }
     else
@@ -42,7 +38,6 @@ try
     }
 
     UploadSymbolsOnSauceLabs(app, transaction, client);
-    // UploadSymbolsOnSauceLabs(username, accessKey, app, transaction, client);
 
     transaction.Finish();
 }

--- a/src/SymbolCollector.Runner/SauceLabsClient.cs
+++ b/src/SymbolCollector.Runner/SauceLabsClient.cs
@@ -1,4 +1,3 @@
-using System.Net;
 using OpenQA.Selenium.Remote;
 
 namespace SymbolCollector.Runner;

--- a/src/SymbolCollector.Runner/SauceLabsClient.cs
+++ b/src/SymbolCollector.Runner/SauceLabsClient.cs
@@ -21,7 +21,7 @@ public class SauceLabsClient
             new SentryHttpCommandExecutor(
                 HttpClient,
                 new Uri(DriverUrl),
-                TimeSpan.FromSeconds(2),
+                TimeSpan.FromMinutes(5),
                 // TimeSpan.FromSeconds(5),
                 true),
             options);
@@ -42,14 +42,13 @@ public class SauceLabsClient
     private static HttpClient CreateHttpClient(string username, string accessKey)
     {
         var handler = new HttpClientHandler();
-        // handler.Credentials = new NetworkCredential(username, accessKey);
-        // handler.PreAuthenticate = true;
 
         var sentryHandler = new SentryHttpMessageHandler(handler);
 
         var client = new HttpClient(sentryHandler);
-        // var byteArray = System.Text.Encoding.ASCII.GetBytes($"{username}:{accessKey}");
-        // client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(byteArray));
+        // Basic auth used to call web APIs like apk upload
+        var byteArray = System.Text.Encoding.ASCII.GetBytes($"{username}:{accessKey}");
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(byteArray));
 
         // client.DefaultRequestHeaders.UserAgent.ParseAdd("selenium/{0} (.net Appium)");
         client.DefaultRequestHeaders.Accept.ParseAdd("application/json, image/png");

--- a/src/SymbolCollector.Runner/SauceLabsClient.cs
+++ b/src/SymbolCollector.Runner/SauceLabsClient.cs
@@ -1,0 +1,102 @@
+using System.Net;
+using OpenQA.Selenium.Remote;
+
+namespace SymbolCollector.Runner;
+
+public class SauceLabsClient
+{
+    private const string DriverUrl = "https://ondemand.us-west-1.saucelabs.com:443/wd/hub";
+    private HttpClient? _client;
+    private AndroidDriver? _driver;
+    private readonly string _username;
+    private readonly string _accessKey;
+
+    public AndroidDriver CreateDriver(AppiumOptions options)
+    {
+        if (_driver is not null)
+        {
+            return _driver;
+        }
+        return _driver = new AndroidDriver(
+            new SentryHttpCommandExecutor(
+                HttpClient,
+                new Uri(DriverUrl),
+                TimeSpan.FromSeconds(2),
+                // TimeSpan.FromSeconds(5),
+                true),
+            options);
+        // return _driver = new AndroidDriver(new Uri(DriverUrl), options, TimeSpan.FromMinutes(10));
+    }
+
+    public HttpClient HttpClient => _client ??= CreateHttpClient(_username, _accessKey);
+
+    public SauceLabsClient() : base()
+    {
+        _username = Environment.GetEnvironmentVariable("SAUCE_USERNAME") ??
+                       throw new Exception("SAUCE_USERNAME is not set");
+        _accessKey = Environment.GetEnvironmentVariable("SAUCE_ACCESS_KEY") ??
+                        throw new Exception("SAUCE_ACCESS_KEY is not set");
+
+    }
+
+    private static HttpClient CreateHttpClient(string username, string accessKey)
+    {
+        var handler = new HttpClientHandler();
+        // handler.Credentials = new NetworkCredential(username, accessKey);
+        // handler.PreAuthenticate = true;
+
+        var sentryHandler = new SentryHttpMessageHandler(handler);
+
+        var client = new HttpClient(sentryHandler);
+        // var byteArray = System.Text.Encoding.ASCII.GetBytes($"{username}:{accessKey}");
+        // client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(byteArray));
+
+        // client.DefaultRequestHeaders.UserAgent.ParseAdd("selenium/{0} (.net Appium)");
+        client.DefaultRequestHeaders.Accept.ParseAdd("application/json, image/png");
+        client.DefaultRequestHeaders.ExpectContinue = false;
+        // if (!this.IsKeepAliveEnabled)
+            client.DefaultRequestHeaders.Connection.ParseAdd("close");
+        // client.Timeout = this.serverResponseTimeout;
+
+        return client;
+    }
+
+    // public void Dispose() => _client.Dispose();
+}
+
+public class SentryHttpCommandExecutor : HttpCommandExecutor
+{
+    private readonly HttpClient _client;
+    private readonly TimeSpan _timeout;
+
+    public SentryHttpCommandExecutor(HttpClient client, Uri addressOfRemoteServer, TimeSpan timeout)
+        : base(addressOfRemoteServer, timeout)
+    {
+        _timeout = timeout;
+        _client = client;
+    }
+
+    public SentryHttpCommandExecutor(HttpClient client, Uri addressOfRemoteServer, TimeSpan timeout, bool enableKeepAlive)
+        : base(addressOfRemoteServer, timeout, enableKeepAlive)
+    {
+        _client = client;
+        _timeout = timeout;
+    }
+
+    protected override HttpClient CreateHttpClient()
+    {
+        return _client;
+        var clientHandler = CreateHttpClientHandler();
+        // var handler = new SentryHttpMessageHandler(clientHandler);
+        // var httpClient = new HttpClient(handler);
+        // httpClient.DefaultRequestHeaders.UserAgent.ParseAdd(this.UserAgent);
+        // httpClient.DefaultRequestHeaders.Accept.ParseAdd("application/json, image/png");
+        // httpClient.DefaultRequestHeaders.ExpectContinue = false;
+        // if (!IsKeepAliveEnabled)
+        // {
+        //     httpClient.DefaultRequestHeaders.Connection.ParseAdd("close");
+        // }
+        // httpClient.Timeout = _timeout;
+        // return httpClient;
+    }
+}

--- a/src/SymbolCollector.Runner/SymbolCollector.Runner.csproj
+++ b/src/SymbolCollector.Runner/SymbolCollector.Runner.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net9.0</TargetFramework>
+    <RootNamespace>SymbolCollector.Runner</RootNamespace>
     <SentryProject>android-symbol-collector-runner</SentryProject>
   </PropertyGroup>
 


### PR DESCRIPTION
making it easier to land more operations like getting all devices etc but moving some HTTP related stuff into a client class

Also fixes an issue where the Runner having Sentry disabled resulted in crashing the mobile app:
* https://github.com/getsentry/sentry-dotnet/issues/4240