### PR TITLE
fix(cloudbuild): using proper repo name

### DIFF
--- a/gocd/pipelines/symbol-collector.yaml
+++ b/gocd/pipelines/symbol-collector.yaml
@@ -40,7 +40,7 @@ pipelines:
                               - script: |
                                     /devinfra/scripts/checks/googlecloud/check_cloudbuild.py \
                                     sentryio \
-                                    symbol-collector \
+                                    github_getsentry_symbol-collector \
                                     symbol-collector-push-to-any-branch \
                                     ${GO_REVISION_SYMBOL_COLLECTOR_REPO} \
                                     main


### PR DESCRIPTION
Not sure why this is the repo name is specified as this in the substitution variables, but it's likely defined somewhere that I can't readily find. I did find this PR which mentions something similar: https://github.com/getsentry/symbol-collector/pull/10. We should probably find all repos with this "issue" and fix them all if this is not expected behavior at some point.