### PR TITLE
fix tracing client-server

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <SentryVersion>5.9.0</SentryVersion>
+    <SentryVersion>5.11.0-alpha.1</SentryVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Sentry" Version="$(SentryVersion)" />

--- a/src/SymbolCollector.Android.Library/AndroidUploader.cs
+++ b/src/SymbolCollector.Android.Library/AndroidUploader.cs
@@ -15,7 +15,7 @@ public class AndroidUploader
         _logger = logger;
     }
 
-    public Task StartUpload(string friendlyName, CancellationToken token) =>
+    public Task StartUpload(string friendlyName, ISpan uploadSpan, CancellationToken token) =>
         Task.Run(async () =>
         {
             var paths = new[] { "/system/lib", "/system/lib64", "/system/", "/vendor/lib" };
@@ -23,17 +23,21 @@ public class AndroidUploader
             _logger.LogInformation("Using friendly name: {friendlyName} and paths: {paths}",
                 friendlyName, paths);
 
+            var androidUploaderSpan = uploadSpan.StartChild("androidUpload", "uploading all paths async");
             try
             {
-                await _client.UploadAllPathsAsync(friendlyName, BatchType.Android, paths, token);
+                await _client.UploadAllPathsAsync(friendlyName, BatchType.Android, paths, androidUploaderSpan, token);
+                androidUploaderSpan.Finish();
             }
             catch (OperationCanceledException)
             {
+                androidUploaderSpan.Finish(SpanStatus.Cancelled);
             }
             catch (Exception e)
             {
                 _logger.LogError(e, "Failed uploading {friendlyName} paths: {paths}",
                     friendlyName, paths);
+                androidUploaderSpan.Finish(e);
                 // Make sure event is flushed and rethrow
                 await SentrySdk.FlushAsync(TimeSpan.FromSeconds(3));
                 throw;

--- a/src/SymbolCollector.Android.Library/AutoUploader.cs
+++ b/src/SymbolCollector.Android.Library/AutoUploader.cs
@@ -67,7 +67,7 @@ public class AutoUploader : Java.Lang.Object
                 s.Contexts.OperatingSystem.KernelVersion = uname.Release;
             }
         });
-        var uploadTask = uploader.StartUpload(friendlyName, source.Token);
+        var uploadTask = uploader.StartUpload(friendlyName, tran, source.Token);
         uploadTask.ContinueWith(t =>
         {
             tran.Finish(t.IsCompletedSuccessfully ? SpanStatus.Ok : SpanStatus.UnknownError);

--- a/src/SymbolCollector.Console/ConsoleUploader.cs
+++ b/src/SymbolCollector.Console/ConsoleUploader.cs
@@ -59,7 +59,7 @@ internal class ConsoleUploader
             var type = batchType ?? DeviceBatchType();
             _logger.LogInformation("Uploading bundle {bundleId} of type {type} and paths: {paths}",
                 bundleId, type, paths);
-            await _client.UploadAllPathsAsync(bundleId, type, paths, token);
+            await _client.UploadAllPathsAsync(bundleId, type, paths, transaction, token);
             transaction.Finish(SpanStatus.Ok);
         }
         catch (Exception e)

--- a/src/SymbolCollector.Core/Client.cs
+++ b/src/SymbolCollector.Core/Client.cs
@@ -73,7 +73,6 @@ public class Client : IDisposable
 
             // use this as parent to all outgoing HTTP requests now:
             SentrySdk.ConfigureScope(s => s.Span = uploadSpan);
-            int i = 0;
             try
             {
                 foreach (var group in groups)

--- a/src/SymbolCollector.Core/Client.cs
+++ b/src/SymbolCollector.Core/Client.cs
@@ -78,7 +78,7 @@ public class Client : IDisposable
             {
                 foreach (var group in groups)
                 {
-                    if (i++ == 3) break;
+                    if (i++ == 2) break;
                     await UploadParallel(batchId, group, cancellationToken);
                 }
                 uploadSpan.Finish(SpanStatus.Ok);

--- a/src/SymbolCollector.Core/Client.cs
+++ b/src/SymbolCollector.Core/Client.cs
@@ -78,7 +78,6 @@ public class Client : IDisposable
             {
                 foreach (var group in groups)
                 {
-                    if (i++ == 2) break;
                     await UploadParallel(batchId, group, cancellationToken);
                 }
                 uploadSpan.Finish(SpanStatus.Ok);

--- a/src/SymbolCollector.Core/Client.cs
+++ b/src/SymbolCollector.Core/Client.cs
@@ -137,8 +137,6 @@ public class Client : IDisposable
             {
                 tasks.Add(UploadFilesAsync(batchId, path, cancellationToken));
                 Metrics.JobsInFlightAdd(1);
-                // TODO: Remove me. Keeping it short to test e2e
-                // return;
             }
             else
             {

--- a/test/SymbolCollector.Core.Tests/ClientTests.cs
+++ b/test/SymbolCollector.Core.Tests/ClientTests.cs
@@ -70,7 +70,7 @@ public class ClientTests
             new HttpClient(_fixture.HttpMessageHandler));
 
         var sut = _fixture.GetSut();
-        await sut.UploadAllPathsAsync("friendly name", BatchType.IOS, new[] {"TestFiles"}, CancellationToken.None);
+        await sut.UploadAllPathsAsync("friendly name", BatchType.IOS, new[] {"TestFiles"}, SentrySdk.StartTransaction("test", "test-op"), CancellationToken.None);
 
         // number of valid test files in TestFiles
         Assert.Equal(12, counter);
@@ -84,7 +84,7 @@ public class ClientTests
             Substitute.For<ILogger<ObjectFileParser>>(), new FatBinaryReader());
 
         var sut = _fixture.GetSut();
-        await sut.UploadAllPathsAsync("friendly name", BatchType.IOS, new[] {"TestFiles"}, CancellationToken.None);
+        await sut.UploadAllPathsAsync("friendly name", BatchType.IOS, new[] {"TestFiles"}, SentrySdk.StartTransaction("test", "test-op"), CancellationToken.None);
 
         // Make sure all valid test files were picked up
         var testFiles = new ObjectFileResultTestCases()


### PR DESCRIPTION
If the full batch runs, the transaction on the client is somehow silently dropped. I only get to see the full transaction complete if I only let the first group (50 paths) run:

![image](https://github.com/user-attachments/assets/6b3d9cb6-ba6c-4e51-9dd6-75ff20c5cbe0)

Another odd thing is the time between the client and server not matching. But since the server is 0ms right now, I'll focus on adding batching:
* https://github.com/getsentry/symbol-collector/issues/230

Depends on (used an alpha release of this branch):
* https://github.com/getsentry/sentry-dotnet/pull/4264