### PR TITLE
Revert "ref(gocd): update gocd script to use console script entry point"

### DIFF
--- a/gocd/pipelines/symbol-collector.yaml
+++ b/gocd/pipelines/symbol-collector.yaml
@@ -32,13 +32,13 @@ pipelines:
                           elastic_profile_id: symbol-collector
                           tasks:
                               - script: |
-                                    checks-githubactions-checkruns \
+                                    /devinfra/scripts/checks/githubactions/checkruns.py \
                                     getsentry/symbol-collector \
                                     ${GO_REVISION_SYMBOL_COLLECTOR_REPO} \
                                     macos-latest \
                                     windows-latest
                               - script: |
-                                    checks-googlecloud-check-cloudbuild \
+                                    /devinfra/scripts/checks/googlecloud/check_cloudbuild.py \
                                     sentryio \
                                     github_getsentry_symbol-collector \
                                     symbol-collector-push-to-any-branch \
@@ -53,7 +53,7 @@ pipelines:
                           tasks:
                               - script: |
                                     /devinfra/scripts/k8s/k8stunnel \
-                                    && k8s-deploy \
+                                    && /devinfra/scripts/k8s/k8s-deploy.py \
                                     --label-selector="service=symbol-collector" \
                                     --image="us-central1-docker.pkg.dev/sentryio/symbol-collector/image:${GO_REVISION_SYMBOL_COLLECTOR_REPO}" \
                                     --container-name="symbol-collector"


### PR DESCRIPTION
Reverts getsentry/symbol-collector#235

Fails with:

```
3623d90b-114e-478f-a6a1-9308cd13310a.sh: line 2: checks-googlecloud-check-cloudbuild: command not found

```

https://deploy.getsentry.net/go/tab/build/detail/deploy-symbol-collector/30/checks/1/checks