### PR TITLE
ref(gocd): Update gocd script to use console script entry point (reapplies #235)

### DIFF
--- a/gocd/pipelines/symbol-collector.yaml
+++ b/gocd/pipelines/symbol-collector.yaml
@@ -32,13 +32,13 @@ pipelines:
                           elastic_profile_id: symbol-collector
                           tasks:
                               - script: |
-                                    /devinfra/scripts/checks/githubactions/checkruns.py \
+                                    checks-githubactions-checkruns \
                                     getsentry/symbol-collector \
                                     ${GO_REVISION_SYMBOL_COLLECTOR_REPO} \
                                     macos-latest \
                                     windows-latest
                               - script: |
-                                    /devinfra/scripts/checks/googlecloud/check_cloudbuild.py \
+                                    checks-googlecloud-check-cloudbuild \
                                     sentryio \
                                     github_getsentry_symbol-collector \
                                     symbol-collector-push-to-any-branch \
@@ -52,8 +52,8 @@ pipelines:
                           elastic_profile_id: symbol-collector
                           tasks:
                               - script: |
-                                    /devinfra/scripts/k8s/k8stunnel \
-                                    && /devinfra/scripts/k8s/k8s-deploy.py \
+                                    /devinfra/scripts/get-cluster-credentials \
+                                    && k8s-deploy \
                                     --label-selector="service=symbol-collector" \
                                     --image="us-central1-docker.pkg.dev/sentryio/symbol-collector/image:${GO_REVISION_SYMBOL_COLLECTOR_REPO}" \
                                     --container-name="symbol-collector"


### PR DESCRIPTION
Updating gocd scripts to use console script entry points.

Also updates old k8s script reference.

Please see: https://github.com/getsentry/devinfra-deployment-service/pull/698

Reapplies: https://github.com/getsentry/symbol-collector/pull/235
