### PR TITLE
bump Sentry SDK for improvements and fixes in Logs

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <SentryVersion>5.12.0-alpha.0</SentryVersion>
+    <SentryVersion>5.14.0</SentryVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Sentry" Version="$(SentryVersion)" />

--- a/src/SymbolCollector.Core/SymbolCollector.Core.csproj
+++ b/src/SymbolCollector.Core/SymbolCollector.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net9.0</TargetFrameworks>
     <UseSentryCLI>false</UseSentryCLI>
   </PropertyGroup>
 

--- a/src/SymbolCollector.Core/SymbolCollector.Core.csproj
+++ b/src/SymbolCollector.Core/SymbolCollector.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
     <UseSentryCLI>false</UseSentryCLI>
   </PropertyGroup>
 


### PR DESCRIPTION
Logs:
- notable improvements since `5.12.0-alpha.0`
  - improved performance of buffering and batching
  - more default attributes like `EventId` and `TCategoryName` via `ILogger<T>`
- notable fixes since `5.12.0-alpha.0`
  - failing to log when `Microsoft.Extensions.Logging` template does not match the amount of parameters
  - passed message arguments via `ILogger<T>` not resolved correctly 
  - log milliseconds precision, rather than just seconds