### PR TITLE
add Serilog integration for Structured Logs

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <SentryVersion>5.14.0</SentryVersion>
+    <SentryVersion>5.16.0</SentryVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Sentry" Version="$(SentryVersion)" />

--- a/src/SymbolCollector.Android.Library/Host.cs
+++ b/src/SymbolCollector.Android.Library/Host.cs
@@ -38,12 +38,8 @@ public class Host
     {
         SentrySdk.Init(o =>
         {
-
-#pragma warning disable SENTRY0001
-            o.Experimental.EnableLogs = true;
-#pragma warning restore SENTRY0001
-
             o.CaptureFailedRequests = true;
+            o.Experimental.EnableLogs = true;
 
             o.SetBeforeSend(@event =>
             {

--- a/src/SymbolCollector.Console/Program.cs
+++ b/src/SymbolCollector.Console/Program.cs
@@ -219,10 +219,7 @@ internal class Program
             o.Debug = true;
             o.IsGlobalModeEnabled = true;
             o.CaptureFailedRequests = true;
-
-#pragma warning disable SENTRY0001
             o.Experimental.EnableLogs = true;
-#pragma warning restore SENTRY0001
 
 #if DEBUG
             o.Environment = "development";

--- a/src/SymbolCollector.Core/Startup.cs
+++ b/src/SymbolCollector.Core/Startup.cs
@@ -34,9 +34,7 @@ public class Startup
                 // TODO: Should also be added via IHostBuilder extension
                 l.AddSentry(o =>
                 {
-#pragma warning disable SENTRY0001
                     o.Experimental.EnableLogs = true;
-#pragma warning restore SENTRY0001
                     o.InitializeSdk = false;
                 });
                 l.AddSimpleConsole(o => o.ColorBehavior = LoggerColorBehavior.Disabled);

--- a/src/SymbolCollector.Runner/Program.cs
+++ b/src/SymbolCollector.Runner/Program.cs
@@ -1,6 +1,5 @@
 ﻿// Runner uploads the apk by default (on current directory or under the apps' bin).
 // To skip, pass 'skipUpload:true' as the first argument
-#pragma warning disable SENTRY0001
 var skipUpload = args.Any(a => a.Equals("skipUpload:true", StringComparison.OrdinalIgnoreCase));
 
 IntrLog.Info($"Starting runner (skipUpload:{skipUpload})...");
@@ -36,7 +35,6 @@ SentrySdk.Init(options =>
     options.Debug = false;
     options.AutoSessionTracking = true;
     options.TracesSampleRate = 1.0;
-
     options.Experimental.EnableLogs = true;
 });
 
@@ -258,13 +256,13 @@ static class IntrLog
     public static void Info(string message, params object[] args)
     {
         Console.WriteLine(message, args);
-        SentrySdk.Experimental.Logger.LogInfo(message, args);
+        SentrySdk.Logger.LogInfo(message, args);
     }
 
     public static void Warning(string message, params object[] args)
     {
         Console.WriteLine(message, args);
-        SentrySdk.Experimental.Logger.LogWarning(message, args);
+        SentrySdk.Logger.LogWarning(message, args);
     }
 
     public static void Error(string message, Exception? exception = null, params object[] args)
@@ -274,11 +272,11 @@ static class IntrLog
         if (exception != null)
         {
             Console.WriteLine(exception);
-            SentrySdk.Experimental.Logger.LogError($"{message} - {exception.Message}", args);
+            SentrySdk.Logger.LogError($"{message} - {exception.Message}", args);
         }
         else
         {
-            SentrySdk.Experimental.Logger.LogError(message, args);
+            SentrySdk.Logger.LogError(message, args);
         }
     }
 }

--- a/src/SymbolCollector.Server/Program.cs
+++ b/src/SymbolCollector.Server/Program.cs
@@ -74,6 +74,7 @@ public class Program
                     o.AddExceptionFilterForType<OperationCanceledException>();
                     o.MinimumBreadcrumbLevel = LogLevel.Debug;
                     o.CaptureFailedRequests = true;
+                    o.Experimental.EnableLogs = true;
 
                     // https://github.com/getsentry/symbol-collector/issues/205
                     // o.CaptureBlockingCalls = true;
@@ -99,7 +100,6 @@ public class Program
                     });
 
 #pragma warning disable SENTRY0001
-                    o.Experimental.EnableLogs = true;
                     o.EnableHeapDumps(20, Debouncer.PerDay(3, TimeSpan.FromHours(3)));
 #pragma warning restore SENTRY0001
                 });


### PR DESCRIPTION
The Sentry .NET SDK added a `Serilog`-integration for _Structured Logs_ in [5.16.0](https://github.com/getsentry/sentry-dotnet/blob/main/CHANGELOG.md#5160).

Also, removed the `ExperimentalAttribute` from all Log-APIs, alongside some other smaller fixes.
